### PR TITLE
Fixed inserting the wrong classname into the table

### DIFF
--- a/rule_maintenance/src/com/datamelt/db/DatabaseCreator.java
+++ b/rule_maintenance/src/com/datamelt/db/DatabaseCreator.java
@@ -499,7 +499,7 @@ public class DatabaseCreator
 		    	
 		    	Action action = new Action();
 				action.setConnection(connection);
-				action.setClassname(Constants.PACKAGE_RULEENGINE_CHECKS + "." + genericAction.getSimpleName());
+				action.setClassname(Constants.PACKAGE_RULEENGINE_ACTIONS + "." + genericAction.getSimpleName());
 				action.setMethodname(method.getName());
 	
 				boolean actionExists = action.exist();


### PR DESCRIPTION
After creating the database an imported project was not able to fill in the appropriate actions. This is caused by a wrong classname in the table 'action'.