### PR TITLE
Fixed some actions from not working

### DIFF
--- a/rule_maintenance/src/com/datamelt/db/CreateDatabase.java
+++ b/rule_maintenance/src/com/datamelt/db/CreateDatabase.java
@@ -314,8 +314,8 @@ public class CreateDatabase
     
     public static final String CREATE_GROUPUSERS = "INSERT INTO " + TABLE_GROUPUSER + " VALUES (1,1,1,now())";
     
-    public static final String CREATE_TYPES =  "INSERT INTO " + TABLE_TYPES + " VALUES (1,'string',now()),"
-    			+ "(2,'integer',now()),"
+    public static final String CREATE_TYPES =  "INSERT INTO " + TABLE_TYPES + " VALUES (1,'String',now()),"
+    			+ "(2,'int',now()),"
     			+ "(3,'float',now()),"
     			+ "(4,'double',now()),"
     			+ "(5,'boolean',now()),"

--- a/rule_maintenance/src/com/datamelt/db/DbCollections.java
+++ b/rule_maintenance/src/com/datamelt/db/DbCollections.java
@@ -914,7 +914,7 @@ public class DbCollections
         }
         else
         {
-        	compareTypeSql = "compare = '" + convertType(compareType) + "'";
+        	compareTypeSql = "compare = '" + compareType + "'";
         }
         String compareToTypeSql;
         if(compareToType==null)
@@ -923,7 +923,7 @@ public class DbCollections
         }
         else
         {
-        	compareToTypeSql = "compare_to = '" + convertType(compareToType) + "'";
+        	compareToTypeSql = "compare_to = '" + compareToType + "'";
         }
         String sql="select count(1) as counter from check_method where check_id=" + checkId +
         		" and " + compareTypeSql + " and " + compareToTypeSql;
@@ -936,19 +936,6 @@ public class DbCollections
         }
         rs.close();
         return numberOfMethods>=1;
-    }
-    
-    private static String convertType(String type)
-    {
-    	// the database contains int and not integer - so we translate it here
-    	if(type.equals("integer"))
-    	{
-    		return "int";
-    	}
-    	else
-    	{
-    		return type;
-    	}
     }
     
     /**
@@ -1039,7 +1026,7 @@ public class DbCollections
     		}
     		// check if a method from the db equals to the method specified by the user
     		// and if the return type is the same
-    		if(methodTypes.equals(buffer.toString().toLowerCase()) && actionReturnType.toLowerCase().equals(object2Type.toLowerCase()))
+    		if(methodTypes.toLowerCase().equals(buffer.toString().toLowerCase()) && actionReturnType.toLowerCase().equals(object2Type.toLowerCase()))
     		{
     			found++;
     			break;


### PR DESCRIPTION
The automatic db creation brought in a bug where some actions could not be executed.
I think mainly this has to with the 'integer' type. 
I propose to change the global 'integer' type to 'int'.
Though this might not be as intuitive for business users, it makes development way easier.
A business user might not know what an integer type, without googling, is anyways.
So I see barely any drawbacks.